### PR TITLE
Babel module formatters are deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ exports.translate = function (load) {
   options.stage = babelOptions.stage || 0;
   options.optional = babelOptions.optional || ['runtime'];
   options.plugins = (babelOptions.plugins || []).concat(hotPlugin);
-  options.modules = 'system';
   
   try {
     options.sourceMaps = true;


### PR DESCRIPTION
Babel module formatters are now deprecated and this line breaks imports under JSPM when specifying package formats explicitly. The babel option 'modules' should remain undefined.